### PR TITLE
Asyncio supervisor

### DIFF
--- a/Lib/asyncio/__init__.py
+++ b/Lib/asyncio/__init__.py
@@ -34,7 +34,6 @@ __all__ = (base_events.__all__ +
            queues.__all__ +
            streams.__all__ +
            subprocess.__all__ +
-           supervisor.__all__ +
            tasks.__all__ +
            threads.__all__ +
            timeouts.__all__ +

--- a/Lib/asyncio/__init__.py
+++ b/Lib/asyncio/__init__.py
@@ -16,6 +16,7 @@ from .runners import *
 from .queues import *
 from .streams import *
 from .subprocess import *
+from .supervisor import *
 from .tasks import *
 from .taskgroups import *
 from .timeouts import *
@@ -33,6 +34,7 @@ __all__ = (base_events.__all__ +
            queues.__all__ +
            streams.__all__ +
            subprocess.__all__ +
+           supervisor.__all__ +
            tasks.__all__ +
            threads.__all__ +
            timeouts.__all__ +

--- a/Lib/asyncio/supervisor.py
+++ b/Lib/asyncio/supervisor.py
@@ -1,0 +1,207 @@
+__all__ = ["Supervisor"]
+
+from . import events
+from . import exceptions
+from . import tasks
+
+
+class Supervisor:
+
+    def __init__(self):
+        self._entered = False
+        self._exiting = False
+        self._aborting = False
+        self._loop = None
+        self._parent_task = None
+        self._parent_cancel_requested = False
+        self._tasks = set()
+        self._errors = []
+        self._base_error = None
+        self._on_completed_fut = None
+
+    def __repr__(self):
+        info = ['']
+        if self._tasks:
+            info.append(f'tasks={len(self._tasks)}')
+        if self._errors:
+            info.append(f'errors={len(self._errors)}')
+        if self._aborting:
+            info.append('cancelling')
+        elif self._entered:
+            info.append('entered')
+
+        info_str = ' '.join(info)
+        return f'<Supervisor{info_str}>'
+
+    async def __aenter__(self):
+        if self._entered:
+            raise RuntimeError(
+                f"Supervisor {self!r} has been already entered")
+        self._entered = True
+
+        if self._loop is None:
+            self._loop = events.get_running_loop()
+
+        self._parent_task = tasks.current_task(self._loop)
+        if self._parent_task is None:
+            raise RuntimeError(
+                f'Supervisor {self!r} cannot determine the parent task')
+
+        return self
+
+    async def __aexit__(self, et, exc, tb):
+        self._exiting = True
+
+        if (exc is not None and
+                self._is_base_error(exc) and
+                self._base_error is None):
+            self._base_error = exc
+
+        propagate_cancellation_error = \
+            exc if et is exceptions.CancelledError else None
+        if self._parent_cancel_requested:
+            # If this flag is set we *must* call uncancel().
+            if self._parent_task.uncancel() == 0:
+                # If there are no pending cancellations left,
+                # don't propagate CancelledError.
+                propagate_cancellation_error = None
+
+        prop_ex = await self._wait_completion()
+        assert not self._tasks
+        if prop_ex is not None:
+            propagate_cancellation_error = prop_ex
+
+        if self._base_error is not None:
+            raise self._base_error
+
+        # Propagate CancelledError if there is one, except if there
+        # are other errors -- those have priority.
+        if propagate_cancellation_error and not self._errors:
+            raise propagate_cancellation_error
+
+        if et is not None and et is not exceptions.CancelledError:
+            self._errors.append(exc)
+
+        if self._errors:
+            # Exceptions are heavy objects that can have object
+            # cycles (bad for GC); let's not keep a reference to
+            # a bunch of them.
+            try:
+                me = BaseExceptionGroup('unhandled errors in a Supervisor', self._errors)
+                raise me from None
+            finally:
+                self._errors = None
+
+    def create_task(self, coro, *, name=None, context=None):
+        if not self._entered:
+            raise RuntimeError(f"Supervisor {self!r} has not been entered")
+        if self._exiting and not self._tasks:
+            raise RuntimeError(f"Supervisor {self!r} is finished")
+        if self._aborting:
+            raise RuntimeError(f"Supervisor {self!r} is shutting down")
+        if context is None:
+            task = self._loop.create_task(coro)
+        else:
+            task = self._loop.create_task(coro, context=context)
+        tasks._set_task_name(task, name)
+        task.add_done_callback(self._on_task_done)
+        self._tasks.add(task)
+        return task
+
+    # Since Python 3.8 Tasks propagate all exceptions correctly,
+    # except for KeyboardInterrupt and SystemExit which are
+    # still considered special.
+
+    def _is_base_error(self, exc: BaseException) -> bool:
+        assert isinstance(exc, BaseException)
+        return isinstance(exc, (SystemExit, KeyboardInterrupt))
+
+    def _abort(self):
+        self._aborting = True
+
+        for t in self._tasks:
+            if not t.done():
+                t.cancel()
+
+    async def _wait_completion(self):
+        # We use while-loop here because "self._on_completed_fut"
+        # can be cancelled multiple times if our parent task
+        # is being cancelled repeatedly (or even once, when
+        # our own cancellation is already in progress)
+        propagate_cancellation_error = None
+        while self._tasks:
+            if self._on_completed_fut is None:
+                self._on_completed_fut = self._loop.create_future()
+
+            try:
+                await self._on_completed_fut
+            except exceptions.CancelledError as ex:
+                if not self._aborting:
+                    # Our parent task is being cancelled:
+                    #
+                    #    async def wrapper():
+                    #        async with TaskGroup() as g:
+                    #            g.create_task(foo)
+                    #
+                    # "wrapper" is being cancelled while "foo" is
+                    # still running.
+                    propagate_cancellation_error = ex
+                    self._abort()
+            self._on_completed_fut = None
+
+        return propagate_cancellation_error
+
+    async def shutdown(self) -> None:
+        self._abort()
+        await self._wait_completion()
+
+    def _on_task_done(self, task):
+        self._tasks.discard(task)
+
+        if self._on_completed_fut is not None and not self._tasks:
+            if not self._on_completed_fut.done():
+                self._on_completed_fut.set_result(True)
+
+        if task.cancelled():
+            return
+
+        exc = task.exception()
+        if exc is None:
+            return
+
+        self._errors.append(exc)
+        if self._is_base_error(exc) and self._base_error is None:
+            self._base_error = exc
+
+        if self._parent_task.done():
+            # Not sure if this case is possible, but we want to handle
+            # it anyways.
+            self._loop.call_exception_handler({
+                'message': f'Task {task!r} has errored out but its parent '
+                           f'task {self._parent_task} is already completed',
+                'exception': exc,
+                'task': task,
+            })
+            return
+
+        if not self._aborting and not self._parent_cancel_requested:
+            # If parent task *is not* being cancelled, it means that we want
+            # to manually cancel it to abort whatever is being run right now
+            # in the TaskGroup.  But we want to mark parent task as
+            # "not cancelled" later in __aexit__.  Example situation that
+            # we need to handle:
+            #
+            #    async def foo():
+            #        try:
+            #            async with Supervisor() as s:
+            #                s.create_task(crash_soon())
+            #                await something  # <- this needs to be waited
+            #                                 #    by the Supervisor
+            #        except Exception:
+            #            # Ignore any exceptions raised in the Supervisor
+            #            pass
+            #        await something_else     # this line has to be called
+            #                                 # after TaskGroup is finished.
+            self._abort()
+            self._parent_cancel_requested = True
+

--- a/Lib/test/test_asyncio/test_supervisor.py
+++ b/Lib/test/test_asyncio/test_supervisor.py
@@ -1,0 +1,215 @@
+# Adapted with permission from the EdgeDB project;
+# license: PSFL.
+
+
+import asyncio
+import contextvars
+import contextlib
+from asyncio import supervisor
+import unittest
+
+
+# To prevent a warning "test altered the execution environment"
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
+class MyExc(Exception):
+    pass
+
+
+class MyBaseExc(BaseException):
+    pass
+
+
+def get_error_types(eg):
+    return {type(exc) for exc in eg.exceptions}
+
+
+class TestSupervisor(unittest.IsolatedAsyncioTestCase):
+
+    async def test_supervisor_01(self):
+
+        async def foo1():
+            await asyncio.sleep(0.1)
+            return 42
+
+        async def foo2():
+            await asyncio.sleep(0.2)
+            return 11
+
+        async with supervisor.Supervisor() as g:
+            t1 = g.create_task(foo1())
+            t2 = g.create_task(foo2())
+
+        self.assertEqual(t1.result(), 42)
+        self.assertEqual(t2.result(), 11)
+
+    async def test_supervisor_02(self):
+
+        async def foo1():
+            await asyncio.sleep(0.1)
+            return 42
+
+        async def foo2():
+            await asyncio.sleep(0.2)
+            return 11
+
+        async with supervisor.Supervisor() as g:
+            t1 = g.create_task(foo1())
+            await asyncio.sleep(0.15)
+            t2 = g.create_task(foo2())
+
+        self.assertEqual(t1.result(), 42)
+        self.assertEqual(t2.result(), 11)
+
+    async def test_supervisor_03(self):
+
+        async def foo1():
+            await asyncio.sleep(1)
+            return 42
+
+        async def foo2():
+            await asyncio.sleep(0.2)
+            return 11
+
+        async with supervisor.Supervisor() as g:
+            t1 = g.create_task(foo1())
+            await asyncio.sleep(0.15)
+            # cancel t1 explicitly, i.e. everything should continue
+            # working as expected.
+            t1.cancel()
+
+            t2 = g.create_task(foo2())
+
+        self.assertTrue(t1.cancelled())
+        self.assertEqual(t2.result(), 11)
+
+    async def test_supervisor_04(self):
+
+        NUM = 0
+        t2_cancel = False
+        t2 = None
+
+        async def foo1():
+            await asyncio.sleep(0.1)
+            1 / 0
+
+        async def foo2():
+            nonlocal NUM, t2_cancel
+            try:
+                await asyncio.sleep(1)
+            except asyncio.CancelledError:
+                t2_cancel = True
+                raise
+            NUM += 1
+
+        async def runner():
+            nonlocal NUM, t2
+
+            async with supervisor.Supervisor() as g:
+                g.create_task(foo1())
+                t2 = g.create_task(foo2())
+
+            NUM += 10   # never reached
+
+        with self.assertRaises(ExceptionGroup) as cm:
+            await asyncio.create_task(runner())
+
+        self.assertEqual(get_error_types(cm.exception), {ZeroDivisionError})
+
+        self.assertEqual(NUM, 1)    # foo2() is not canceled so, NUM == 1
+        self.assertFalse(t2_cancel)
+        self.assertFalse(t2.cancelled())
+    
+    async def test_children_complete_on_child_error(self):
+
+        async def zero_division():
+            1 / 0
+        
+        async def foo1():
+            await asyncio.sleep(0.1)
+            return 42
+        
+        async def foo2():
+            await asyncio.sleep(0.2)
+            return 11
+        
+        with self.assertRaises(ExceptionGroup) as cm:
+            async with supervisor.Supervisor() as g:
+                t1 = g.create_task(foo1())
+                t2 = g.create_task(foo2())
+                g.create_task(zero_division())
+        
+        self.assertEqual(get_error_types(cm.exception), {ZeroDivisionError})
+
+        self.assertEqual(t1.result(), 42)
+        self.assertEqual(t2.result(), 11)
+
+    async def test_children_complete_on_inner_error(self):
+        
+        async def foo1():
+            await asyncio.sleep(0.1)
+            return 42
+        
+        async def foo2():
+            await asyncio.sleep(0.2)
+            return 11
+        
+        with self.assertRaises(ExceptionGroup) as cm:
+            async with supervisor.Supervisor() as g:
+                t1 = g.create_task(foo1())
+                t2 = g.create_task(foo2())
+                1 / 0
+
+        self.assertEqual(get_error_types(cm.exception), {ZeroDivisionError})
+
+        self.assertEqual(t1.result(), 42)
+        self.assertEqual(t2.result(), 11)
+
+    async def test_inner_complete_on_child_error(self):
+
+        async def zero_division():
+            1 / 0
+        
+        async def foo1():
+            await asyncio.sleep(0.1)
+            return 42
+        
+        async def foo2():
+            await asyncio.sleep(0.2)
+            return 11
+        
+        with self.assertRaises(ExceptionGroup) as cm:
+            async with supervisor.Supervisor() as g:
+                t1 = g.create_task(foo1())
+                g.create_task(zero_division())
+                r1 = await foo2()
+        
+        self.assertEqual(get_error_types(cm.exception), {ZeroDivisionError})
+
+        self.assertEqual(t1.result(), 42)
+        self.assertEqual(r1, 11)
+
+    async def test_children_cancel_on_inner_base_error(self):
+        
+        async def foo1():
+            await asyncio.sleep(0.1)
+            return 42
+        
+        async def foo2():
+            await asyncio.sleep(0.2)
+            return 11
+        
+        with self.assertRaises(KeyboardInterrupt) as cm:
+            async with supervisor.Supervisor() as g:
+                t1 = g.create_task(foo1())
+                t2 = g.create_task(foo2())
+                raise KeyboardInterrupt()
+
+        self.assertTrue(t1.cancelled())
+        self.assertTrue(t2.cancelled())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Asyncio Supervisor

Hi @achimnol , I open this draft to ask for some review from you.

I list requirements from the *discuss.python.org* post as a reminder:
* When the persistent task group is cancelled or explicitly shutdown: all child tasks should be cancelled and awaited. → This makes it different from simply shielding child tasks. Propagation of cancellation should be controlled in the task group instead of individual tasks.
* When a child task is cancelled: all other child tasks should remain intact.  (same to the original task group, *ndr*)
* When a child task raised unhandled exception: an exception handler configured in the persistent task group is invoked (the default fallback is loop.call_exception_handler()). All other child tasks should remain intact.
* If all child tasks have finished, the persistent task group should exit as well. (same to the original task group)
* It should guarantee termination of all child tasks if the control flow has exited from the persistent task group. (same to the original task group)

I've defined some basic test in `Lib/test/test_asyncio/test_supervisor.py` to test `asyncio.Supervisor` against the above requirements.

If the actual `asyncio.Supervisor` implementation meets them, I have already implemented a raw version of `asyncio.TaskGroup` that can pass against both `Lib/test/test_asyncio/test_supervisor.py` and `Lib/test/test_asyncio/test_taskgroups.py` (using a flag to select the desired behaviour). ***I haven't pushed it yet***, I'll wait for your review of `asyncio.Supervisor`.
